### PR TITLE
Improving for loops and fixing the diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Test my_ls
 Bash script for testing my_ls program
 
+### WARNING: The tests actually not working, they will be soon fixed
+
 ## Launch script
 Move the script file in your **my_ls** directory, then run `chmod +x test_my_ls.sh` and finally `./test_my_ls.sh` (run as sudo if you're facing permissions issues)
 

--- a/test_my_ls.sh
+++ b/test_my_ls.sh
@@ -22,6 +22,8 @@ function header {
     #      |___  / ____|      \______  /____/\___  >__|_|  /\___  >___|  /__|       |_______ \ /\\     #
     #          \/\/                  \/          \/      \/     \/     \/                   \/ \/     #
     #                                                                                                 #
+    #                                Thanks to Ximaz for Contributing                                 #
+    #                                                                                                 #
     ###################################################################################################\033[0m\n"
 }
 
@@ -36,7 +38,7 @@ function write_error {
 function menu {
     PS3="Select an option (1-2) : "
     local options=( "Continue anyway" "Stop" )
-    
+
     select option in "${options[@]}"; do
         case "${REPLY}" in
             "1" | "2")
@@ -67,8 +69,8 @@ function make_test {
 }
 
 function generate_logs {
-    local flags=( "-a" "-r" "-ar" )
-    local path=("${HOME}" "${HOME}" "${HOME}")
+    local flags=( "-a" "-r" "-t" "-d" "-ar" "-R" "-l" "-alRdrt" "-a" "-r" "-t" "-d" "-ar" "-R" "-l" "-alRdrt" )
+    local path=("./" "./" "./" "./" "./" "./" "./" "./" "/home/${USERNAME}/" "/home/${USERNAME}/" "/home/${USERNAME}/" "/home/${USERNAME}/" "/home/${USERNAME}/" "/home/${USERNAME}/" "/home/${USERNAME}/" "/home/${USERNAME}/")
     local range="${#flags[@]}"
 
     for (( i=0; i<"${range}"; i++)); do echo $(make_test "${flags[${i}]}" "${path[${i}]}" $(( i + 1 ))); done


### PR DESCRIPTION
for loops were improved to avoid code repetition and the diff command has been fixed to pipe to tmp files, it's required to get the output nicely printed, my bad. Yet no verification was made about permissions, because at the first error such as "PermissionError", the script will crash thanks to ``-e`` from the shebang. I then had to put the clean up statements to clear tmp files.